### PR TITLE
Use `read-string' rather than `read-from-minibuffer' when prompting

### DIFF
--- a/xcscope.el
+++ b/xcscope.el
@@ -2849,10 +2849,11 @@ file."
     (if (or (not sym)
             (string= sym "")
             (not (boundp 'cscope-suppress-user-symbol-prompt))
-
             ;; Always prompt for symbol in dired mode.
             (eq major-mode 'dired-mode))
-	(setq sym (read-from-minibuffer prompt sym))
+        (let ((full-prompt (concat prompt
+                                   (if sym (concat "(default " sym "): ")))))
+          (setq sym (read-string full-prompt nil nil sym)))
       sym)
     ))
 


### PR DESCRIPTION
for symbols, filenames, etc. to enable better behaviour and input
history.
