### PR TITLE
fix error about toggling cscope-minor-mode off

### DIFF
--- a/xcscope.el
+++ b/xcscope.el
@@ -2988,7 +2988,7 @@ functions more accessible.
 
 Key bindings:
 \\{cscope-minor-mode-keymap}"
-  nil nil cscope-minor-mode-keymap
+  1 nil cscope-minor-mode-keymap
   (when cscope-minor-mode
     (easy-menu-add cscope-global-menu cscope-minor-mode-keymap)
     (run-hooks 'cscope-minor-mode-hooks)))


### PR DESCRIPTION
Opening a C file would throw this error message:

Toggling c-minor-mode off; better pass an explicit argument

So now setting an explicit argument.