### PR TITLE
Fix "<file> is not readable or exists" when using xcscope over TRAMP.

### DIFF
--- a/xcscope.el
+++ b/xcscope.el
@@ -2343,6 +2343,10 @@ using the mouse."
                           line (substring line (match-beginning 4)
                                           (match-end 4))
                           )
+
+		    ;; handling remote files
+		    (setq file (concat (file-remote-p default-directory) file))
+
                     ;; If the current file is not the same as the previous
                     ;; one ...
                     (if (not (and cscope-last-file


### PR DESCRIPTION
1. The "<file> is not readable or exists" issue:

When using xcscope over TRAMP, the database can be found and the query
results shown correctly.  However, the results cannot be jumped to
with a message "<file> is not readable or exists".  It seems that
xcscope tries the filename on my local machine.  The issue is detailed at #20 .

2. Possible fix (this commit):

When adding text properties, prepend the filename with remote file
identifier if 'default-directory' is remote.