### PR TITLE
Quote and escape file names in index file and allow whitespaces

### DIFF
--- a/xcscope.el
+++ b/xcscope.el
@@ -2342,7 +2342,7 @@ using the mouse."
 
             ;; This should always match.
             (if (string-match
-                 "^\\([^ \t]+\\)[ \t]+\\([^ \t]+\\)[ \t]+\\([0-9]+\\)[ \t]+\\(.*\\)\n"
+                 "^\\([^\t]+\\)[ \t]+\\([^ \t]+\\)[ \t]+\\([0-9]+\\)[ \t]+\\(.*\\)\n"
                  line)
                 (progn
                   (let (str)
@@ -2754,7 +2754,16 @@ indexer"
            (concat "echo 'Creating list of files to index ...'\n"
 
                    "find "
-                   (mapconcat 'identity findargs " ") " > "
+                   (mapconcat 'identity findargs " ") " | "
+                   ;; From cscope(1): filenames in the namefile that contain
+                   ;; whitespace have to be enclosed in "double quotes".
+                   ;; Inside such quoted filenames, any double-quote and
+                   ;; backslash characters have to be escaped by backslashes.
+                   (mapconcat 'identity
+                              (mapcar 'shell-quote-argument
+                                      '("sed" "-e" "s/\\\\/\\\\\\\\/g"
+                                        "-e" "s/\"/\\\\\"/g"
+                                        "-e" "s/.*/\"&\"/")) " ") " > "
                    (shell-quote-argument cscope-index-file) "\n"
 
                    "echo 'Creating list of files to index ... done'\n"))


### PR DESCRIPTION
cscope can handle files with whitespaces and other special characters,
but they must be properly quoted and escaped in the index file. This
can be fixed by filtering the output of 'find' through 'sed'.

cscope still complains when a symbol is found in a file with a
whitespace in its name ("File does not have expected format") but at
least it works (partially) now. On the other hand, filenames with
double quotes or backslashes seem to work just fine.

In addition to that, the regular expression that parses the cscope
output needs to be modified to allow whitespaces in file names. The
new regular expression still does not allow tabs in file names, but
they are extremely unlikely to happen and cscope does not seem to
support them anyway.